### PR TITLE
Remove return values

### DIFF
--- a/apix/diff.py
+++ b/apix/diff.py
@@ -142,7 +142,7 @@ class VersionDiff:
             f"Removed since {self.ver2}": removed,
         }
 
-    def save_diff(self):
+    def save_diff(self, return_path=False):
         """Save the currently stored diff"""
         if not self._vdiff:
             logger.warning("No data to be saved. Exiting.")
@@ -165,4 +165,5 @@ class VersionDiff:
         logger.info(f"Saving results to {fpath}")
         with fpath.open("w+") as outfile:
             yaml.dump(self._vdiff, outfile, default_flow_style=False)
-        return fpath
+        if return_path:
+            return fpath

--- a/apix/explore.py
+++ b/apix/explore.py
@@ -77,7 +77,7 @@ class AsyncExplorer:
             logger.debug(f"Scraping {link[1]}")
             self._data[link[1]] = self.parser.scrape_content(content)
 
-    def save_data(self):
+    def save_data(self, return_path=False):
         """convert the stored data into yaml-friendly dict and save"""
         yaml_data = self.parser.yaml_format(self._data)
         if not yaml_data:
@@ -100,7 +100,8 @@ class AsyncExplorer:
         logger.info(f"Saving results to {fpath}")
         with fpath.open("w+") as outfile:
             yaml.dump(yaml_data, outfile, default_flow_style=False)
-        return fpath
+        if return_path:
+            return fpath
 
     def explore(self):
         """main function for the explore module

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -17,7 +17,7 @@ def test_positive_save_diff():
     vdiff = diff.VersionDiff(data_dir="./", mock=True)
     vdiff.diff()
     assert vdiff._vdiff
-    path = vdiff.save_diff()
+    path = vdiff.save_diff(return_path=True)
     assert Path(path).exists()
     Path(path).unlink()
 

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -13,7 +13,7 @@ def test_positive_explore():
         parser="test",
     )
     assert t_explorer.explore()
-    save_file = t_explorer.save_data()
+    save_file = t_explorer.save_data(return_path=True)
     assert save_file.exists()
     data_dir = save_file.parent
     save_file.unlink()


### PR DESCRIPTION
This should hopefully allow Jenkins to not interpret APIx's output
as a failed step.