### PR TITLE
Add a new API library version that exploits Python's type annotations

### DIFF
--- a/apix/helpers.py
+++ b/apix/helpers.py
@@ -1,5 +1,7 @@
 """A collection of miscellaneous helpers that don't quite fit in."""
+
 from copy import deepcopy
+import html
 from pathlib import Path
 
 from logzero import logger
@@ -104,3 +106,18 @@ def merge_dicts(dict1, dict2):
     for key in dict2.keys() - dupe_keys:
         merged[key] = deepcopy(dict2[key])
     return merged
+
+
+def clean_string(string):
+    """Clean a string by removing html tags and unescaping"""
+    if not string:
+        return ""
+    # unescape html tags
+    string = html.unescape(string)
+    # remove html tags
+    for tag in ("p", "code"):
+        string = string.replace(f"<{tag}>", "")
+        string = string.replace(f"</{tag}>", "")
+    # remove newlines
+    string = string.replace("\n", " ")
+    return string.strip()

--- a/apix/libtools/libmaker.py
+++ b/apix/libtools/libmaker.py
@@ -4,9 +4,10 @@ import attr
 from logzero import logger
 
 from apix import helpers
-from apix.libtools import advanced, basic, intermediate, nailgun
+from apix.libtools import advanced, basic, intermediate, nailgun, typed
 
 TEMPLATE_MAKERS = {
+    "typed": typed.TypedMaker,
     "advanced": advanced.AdvancedMaker,
     "basic": basic.BasicMaker,
     "intermediate": intermediate.IntermediateMaker,

--- a/apix/libtools/satellite.yaml
+++ b/apix/libtools/satellite.yaml
@@ -1,0 +1,26 @@
+# Special mappings for Satellite/Foreman API entity types
+# These map parameter names to their corresponding API entities
+
+special_mappings:
+  medium: "media"
+  ptable: "ptables"
+  smart_proxy: "smart_proxies"
+  environment: "lifecycle_environments"
+  operatingsystem: "operatingsystems"
+  template: "templates"
+  provisioning_template: "provisioning_templates"
+  content_view_version: "content_view_versions"
+  filter: "filters"
+  repository: "repositories"
+  location: "locations"
+  organization: "organizations"
+  host: "hosts"
+  hostgroup: "hostgroups"
+  domain: "domains"
+  realm: "realms"
+  compute_resource: "compute_resources"
+  subnet: "subnets"
+  user: "users"
+  component: "content_view_components"
+  module_stream: "module_streams"
+  rule: "content_view_filter_rules"

--- a/apix/libtools/typed.py
+++ b/apix/libtools/typed.py
@@ -1,0 +1,887 @@
+import builtins
+import keyword
+from pathlib import Path
+import re
+import subprocess
+
+import attr
+from logzero import logger
+import yaml
+
+from apix.helpers import shift_text
+
+# Track all fauxfactory types we encounter and need to generate
+FF_TYPES = set()
+
+
+class TemplateManager:
+    """Handles template loading and manipulation operations"""
+
+    @staticmethod
+    def load_template(template_name):
+        """Load a template file and return its content"""
+        template_path = Path(f"libs/templates/typed/{template_name}.template")
+        if not template_path.exists():
+            logger.error(f"Unable to find template: {template_path.absolute()}")
+            return ""
+
+        return template_path.read_text()
+
+    @staticmethod
+    def replace_placeholders(template, replacements):
+        """Replace all placeholders in a template with their values"""
+        result = template
+        for placeholder, value in replacements.items():
+            result = result.replace(f"~~{placeholder}~~", value)
+        return result
+
+
+@attr.s()
+class CustomEntityMaker:
+    api_dict = attr.ib(repr=False)
+    api_name = attr.ib()
+    api_version = attr.ib()
+    ff_types = attr.ib(factory=set, repr=False)  # Track fauxfactory types needed
+    template_manager = attr.ib(factory=TemplateManager, repr=False)
+    special_mappings = attr.ib(factory=dict, repr=False)  # Special entity mappings from YAML
+
+    def __attrs_post_init__(self):
+        """Load special mappings from YAML file after initialization"""
+        self.special_mappings = self._load_special_mappings()
+
+    def _load_special_mappings(self):
+        """Load special entity mappings from a YAML file based on the API name"""
+        # Get the current file's directory
+        current_dir = Path(__file__).parent
+
+        # Try to find a <product_name>.yaml file
+        product_yaml = current_dir / f"{self.api_name.lower()}.yaml"
+
+        if not product_yaml.exists():
+            logger.debug(f"No special mappings file found at {product_yaml}")
+            return {}
+
+        try:
+            with product_yaml.open() as f:
+                yaml_data = yaml.safe_load(f)
+
+            if not isinstance(yaml_data, dict):
+                logger.warning(f"Invalid YAML format in {product_yaml}")
+                return {}
+
+            mappings = yaml_data.get("special_mappings", {})
+            logger.info(f"Loaded {len(mappings)} special mappings from {product_yaml}")
+            return mappings
+
+        except Exception as e:
+            logger.error(f"Error loading special mappings from {product_yaml}: {e}")
+            return {}
+
+    @staticmethod
+    def name_to_class(entity_name):
+        """Convert an entity name to a class name. ent_name => EntName"""
+        if not entity_name:
+            return ""
+        if entity_name[-1] == "s" and entity_name[-2:] != "ss":  # Keep "address" as "Address"
+            entity_name = entity_name[:-1]
+        return "".join(x.capitalize() or "_" for x in entity_name.split("_"))
+
+    @staticmethod
+    def fix_name(name):
+        """Determine if the name is reserved and adjust if needed"""
+        # Check for Python keywords (like 'global', 'class', etc.)
+        if keyword.iskeyword(name) or name in dir(builtins) or name in ["import", "type", "id"]:
+            original_name = name
+            name = f"{name}_"
+            logger.debug(
+                f"{original_name} is a python keyword/builtin/reserved, changing to {name}"
+            )
+        return name
+
+    @staticmethod
+    def compile_paths(path_list):
+        compiled_paths = []
+        for path_entry in path_list:
+            if isinstance(path_entry, str):  # Original format "METHOD /path"
+                method, path_str = path_entry.split(maxsplit=1)
+            elif isinstance(path_entry, dict):  # New format {"method": "GET", "path": "/path"}
+                method = path_entry.get("method", "GET")
+                path_str = path_entry.get("path", "")
+            else:
+                logger.warning(f"Unknown path format: {path_entry}")
+                continue
+
+            path_recomp = re.sub(r":([a-zA-Z_][a-zA-Z0-9_]*)", r"{\1}", path_str)
+            compiled_paths.append((method, path_recomp))
+        return compiled_paths
+
+    def _load_template(self, template_name):
+        """Load a template file by name"""
+        return self.template_manager.load_template(template_name)
+
+    def get_entity_class_name_if_entity(self, param_name):
+        """
+        Check if the parameter name corresponds to an entity in the API dictionary.
+        If so, return the appropriate class name, otherwise return None.
+        """
+        if not param_name:
+            return None
+
+        # Try with singular form (users -> user)
+        singular_name = (
+            param_name[:-1] if param_name.endswith("s") and param_name[-2:] != "ss" else param_name
+        )
+
+        # If either form exists in API dict, convert to class name
+        if singular_name in self.api_dict:
+            return self.name_to_class(singular_name)
+        if param_name in self.api_dict:
+            return self.name_to_class(param_name)
+
+        return None
+
+    def _detect_type_patterns(self, spec_lower, param_name):
+        """Check for common type patterns in parameter specifications"""
+        type_patterns = [
+            ("Date", r"\bdate\b", "gen_date"),
+            ("DateTime", r"\bdatetime\b", "gen_datetime"),
+            ("Time", r"\btime\b", "gen_time"),
+            ("Domain", r"\bdomain\b", "gen_domain"),
+            ("Email", r"\bemail\b", "gen_email"),
+            ("IPAddress", r"\bip\s?addr(?:ess)?\b", "gen_ipaddr"),
+            ("MACAddress", r"\bmac\s?addr(?:ess)?\b", "gen_mac"),
+            ("URL", r"\burl\b", "gen_url"),
+            ("UUID", r"\buuid\b", "gen_uuid"),
+        ]
+
+        for type_name, pattern, ff_method in type_patterns:
+            if re.search(pattern, spec_lower):
+                self.ff_types.add((type_name, ff_method))
+                return f"ffTypes.{type_name}"
+        return None
+
+    def _detect_special_type(self, param_name):
+        if not param_name:
+            return None
+
+        param_lower = param_name.lower()
+        special_types = [
+            ("date", "Date", "gen_date"),
+            ("datetime", "DateTime", "gen_datetime"),
+            ("time", "Time", "gen_time"),
+            ("domain", "Domain", "gen_domain"),
+            ("email", "Email", "gen_email"),
+            ("ip", "IPAddress", "gen_ipaddr"),
+            ("ipaddr", "IPAddress", "gen_ipaddr"),
+            ("ip_address", "IPAddress", "gen_ipaddr"),
+            ("mac", "MACAddress", "gen_mac"),
+            ("mac_address", "MACAddress", "gen_mac"),
+            ("netmask", "Netmask", "gen_netmask"),
+            ("url", "URL", "gen_url"),
+            ("hex", "Hexadecimal", "gen_hexadecimal"),
+            ("hexadecimal", "Hexadecimal", "gen_hexadecimal"),
+            ("html", "HTML", "gen_html"),
+            ("uuid", "UUID", "gen_uuid"),
+            ("guid", "UUID", "gen_uuid"),
+        ]
+
+        for key, type_name, ff_method in special_types:
+            if key in param_lower or param_lower.endswith(f"_{key}"):
+                self.ff_types.add((type_name, ff_method))
+                return f"ffTypes.{type_name}"
+        return None
+
+    def _detect_enum(self, spec_lower):
+        enum_match = re.search(r"must be one of: ([^\.]+)", spec_lower)
+        if enum_match:
+            enum_values = enum_match.group(1).strip()
+            if "true" in enum_values and "false" in enum_values:
+                return bool
+            choices = [choice.strip() for choice in enum_values.split(",")]
+            return ("Literal", choices)
+        return None
+
+    def _detect_array(self, spec_lower):
+        if "array" in spec_lower or "list" in spec_lower:
+            array_item_match = re.search(r"array of ([a-zA-Z]+)", spec_lower)
+            if array_item_match:
+                item_type = array_item_match.group(1).strip()
+                if item_type in ("number", "integer"):
+                    return list
+            return list
+        return None
+
+    def get_python_type_from_spec(self, spec_string, param_name):  # noqa: PLR0912
+        """Determine Python type from specification string"""
+        spec_lower = spec_string.lower()
+
+        # Early return cases
+        if "deprecated" in spec_lower:
+            logger.debug(f"Parameter {param_name} is deprecated, skipping")
+            return None
+
+        # Check if parameter corresponds to an entity
+        entity_class = self.get_entity_class_name_if_entity(param_name)
+        if entity_class:
+            logger.debug(f"Parameter {param_name} matches an entity in the API")
+            return entity_class
+
+        # Check for enum types
+        enum_type = self._detect_enum(spec_lower)
+        if enum_type:
+            return enum_type
+
+        # Check for identifier/string type
+        if (
+            ("must be an identifier" in spec_lower or "string from" in spec_lower)
+            and "number" not in spec_lower
+            and "integer" not in spec_lower
+        ):
+            return str
+
+        # Check for array type
+        array_type = self._detect_array(spec_lower)
+        if array_type:
+            return array_type
+
+        # Check for special types based on parameter name
+        special_type = self._detect_special_type(param_name)
+        if special_type:
+            return special_type
+
+        # Check for common data structures
+        if "array" in spec_lower or "list" in spec_lower:
+            return list
+        if "object" in spec_lower or "hash" in spec_lower or "dict" in spec_lower:
+            entity = self.get_entity_class_name_if_entity(param_name)
+            if entity:
+                return entity
+            logger.debug(
+                "Parameter %s is an object but not an entity: %s",
+                param_name,
+                spec_string,
+            )
+            return dict
+
+        # Check for numeric types
+        if "number" in spec_lower or "integer" in spec_lower or "numeric" in spec_lower:
+            return int
+
+        # Check for boolean
+        if "boolean" in spec_lower or "true" in spec_lower or "false" in spec_lower:
+            return bool
+
+        # Check for pattern-based types
+        pattern_type = self._detect_type_patterns(spec_lower, param_name)
+        if pattern_type:
+            return pattern_type
+
+        # Check for string types
+        if "string" in spec_lower or "char" in spec_lower:
+            return str
+
+        # Check for ID fields
+        if param_name and (param_name.endswith("_id") or param_name.endswith("_ids")):
+            if "number" in spec_lower or "integer" in spec_lower:
+                return int
+            return str
+
+        # Default to string if no other type identified
+        return str
+
+    def _handle_nested_params(
+        self, current_level, full_name_str, clean_name_parts, i, req_str, desc_str
+    ):
+        """Handle nested parameter parsing logic"""
+        part_name = clean_name_parts[i]
+        is_last_part = i == len(clean_name_parts) - 1
+        is_array_item_spec = part_name == "" and not is_last_part
+
+        if is_array_item_spec:
+            array_name = clean_name_parts[i - 1]
+            children = self._handle_array_item(array_name, current_level, full_name_str)
+            if children is None:
+                return None
+            return children, False
+
+        if is_last_part:
+            current_level[part_name] = {
+                "name": part_name,
+                "required": "required" in req_str.lower(),
+                "type_str": self.get_python_type_from_spec(desc_str, part_name),
+                "description": desc_str,
+                "children": {},
+            }
+            return current_level, True
+
+        if part_name not in current_level:
+            current_level[part_name] = {
+                "name": part_name,
+                "required": "required" in req_str.lower(),
+                "type_str": dict,
+                "description": "",
+                "children": {},
+            }
+        type_str = current_level[part_name]["type_str"]
+        if isinstance(type_str, type) and type_str is not dict and type_str is not list:
+            logger.error(
+                "Parameter %s has sub-parameters like %s but was not defined as a dict or list.",
+                part_name,
+                full_name_str,
+            )
+            return None, True
+
+        return current_level[part_name]["children"], False
+
+    def _handle_array_item(self, array_name, current_level, full_name_str):
+        """Handle array item parameter logic"""
+        if array_name not in current_level:
+            logger.warning(
+                "Array %s not defined before its items. Attempting to create.",
+                array_name,
+            )
+            current_level[array_name] = {
+                "name": array_name,
+                "required": False,
+                "type_str": list,
+                "description": "Array of objects",
+                "children": {},
+            }
+        type_str = current_level[array_name]["type_str"]
+        if not isinstance(type_str, type) or type_str is not list:
+            logger.error(
+                "Parameter %s was not defined as an array but sub-parameters like %s exist.",
+                array_name,
+                full_name_str,
+            )
+            return None
+        return current_level[array_name]["children"]
+
+    def parse_api_parameters(self, api_params_list):
+        """Parse API parameters into a structured format"""
+        MAX_PARTS = 3
+        parsed_params = {}
+        if not api_params_list:
+            return parsed_params
+
+        for param_entry in api_params_list:
+            parts = [p.strip() for p in param_entry.split("~")]
+            if len(parts) < MAX_PARTS:
+                logger.warning(f"Skipping malformed parameter entry: {param_entry}")
+                continue
+
+            full_name_str, req_str, desc_str = parts[0], parts[1], " ".join(parts[2:])
+
+            # Extract name parts from parameter string
+            name_parts = re.findall(r"\[([^\]]+)\]|([^\[\]]+)", full_name_str)
+            clean_name_parts = []
+            for p1, p2 in name_parts:
+                if p1:
+                    clean_name_parts.append(p1)
+                elif p2:
+                    clean_name_parts.append(p2.replace("[]", ""))
+
+            current_level = parsed_params
+
+            # Process each part of the parameter name
+            for i, _ in enumerate(clean_name_parts):
+                result = self._handle_nested_params(
+                    current_level, full_name_str, clean_name_parts, i, req_str, desc_str
+                )
+
+                if result is None:
+                    break
+
+                current_level, done = result
+                if done:
+                    break
+
+        return parsed_params
+
+    def _infer_list_item_type(self, param_name):  # noqa: PLR0912
+        """
+        Try to infer the type of items in a list parameter based on naming patterns.
+        For parameters ending with _ids, try to match with an entity class.
+        Returns tuple (item_type_name, is_id_reference) or None if no match found.
+        """
+        if not param_name or not param_name.endswith("_ids"):
+            return None
+
+        # Extract the potential entity name (remove _ids suffix)
+        base_name = param_name[:-4]  # Remove '_ids'
+
+        # Try singular form if it ends with 's' (but not 'ss')
+        if base_name.endswith("s") and not base_name.endswith("ss"):
+            entity_name = base_name[:-1]
+        else:
+            entity_name = base_name
+
+        # Try to find entity in special mappings loaded from YAML
+        if entity_name in self.special_mappings:
+            mapped_name = self.special_mappings[entity_name]
+            if mapped_name in self.api_dict:
+                logger.debug(f"Mapped {entity_name} to {mapped_name}")
+                return (
+                    self.name_to_class(
+                        mapped_name[:-1] if mapped_name.endswith("s") else mapped_name
+                    ),
+                    True,
+                )
+
+        # Try the special mapping first
+        if entity_name in self.special_mappings:
+            mapped_name = self.special_mappings[entity_name]
+            if mapped_name in self.api_dict:
+                logger.debug(f"Mapped {entity_name} to {mapped_name}")
+                return (
+                    self.name_to_class(
+                        mapped_name[:-1] if mapped_name.endswith("s") else mapped_name
+                    ),
+                    True,
+                )
+
+        # Try direct match with API dict keys (singular form)
+        if entity_name in self.api_dict:
+            return (self.name_to_class(entity_name), True)
+
+        # Try direct match with original base_name
+        if base_name in self.api_dict:
+            return (self.name_to_class(base_name), True)
+
+        # Try to find a plural form in the API dictionary that matches our singular name
+        # This is useful for cases like "host_ids" where we need to map to "hosts"
+        for api_key in self.api_dict:
+            # Skip keys that don't end with 's'
+            if not api_key.endswith("s"):
+                continue
+
+            # Get the singular form of the API key
+            api_key_singular = api_key[:-1]
+
+            # If our entity name matches the singular API key, use the API key class
+            if entity_name == api_key_singular:
+                logger.debug(f"Found plural form {api_key} for {entity_name}")
+                return (self.name_to_class(api_key_singular), True)
+
+        # Try a more lenient match - check if entity_name is contained in any API key
+        # Helps with compound names like "content_view_version" matching "content_view_versions"
+        for api_key in self.api_dict:
+            if entity_name in api_key:
+                logger.debug(f"Found partial match {api_key} for {entity_name}")
+                # Get class name from API key but keep it singular
+                return (
+                    self.name_to_class(api_key[:-1] if api_key.endswith("s") else api_key),
+                    True,
+                )
+
+        # Finally try the base_name with the same approach
+        for api_key in self.api_dict:
+            if base_name in api_key:
+                logger.debug(f"Found partial match {api_key} for {base_name}")
+                # Get class name from API key but keep it singular
+                return (
+                    self.name_to_class(api_key[:-1] if api_key.endswith("s") else api_key),
+                    True,
+                )
+
+        # Log at debug level instead of warning since this is expected for some parameters
+        logger.debug(f"Could not find entity class for list parameter {param_name}")
+        return None
+
+    def get_python_type_annotation(self, param_details, param_name=None):
+        """
+        Convert parameter details to a Python type annotation string.
+        Returns: A string representing the type annotation (e.g., "str", "int | None")
+        """
+        type_value = param_details["type_str"]
+        is_required = param_details["required"]
+
+        # Handle lists with potential entity item types
+        if isinstance(type_value, type) and type_value is list and param_name:
+            list_item_info = self._infer_list_item_type(param_name)
+            if list_item_info:
+                entity_class, is_id_ref = list_item_info
+                type_str = f"list[{entity_class}.id]" if is_id_ref else f"list[{entity_class}]"
+            else:
+                type_str = "list"
+        # Handle Literal type with enumeration values
+        elif isinstance(type_value, tuple) and type_value[0] == "Literal":
+            # For Literal type, create a proper Literal annotation
+            choices_str = ", ".join([f'"{choice}"' for choice in type_value[1]])
+            type_str = f"Literal[{choices_str}]"
+        # Handle entity class references
+        elif isinstance(type_value, str):
+            if type_value[0].isupper():
+                # This is a class name reference
+                type_str = type_value
+            elif type_value in [
+                "Date",
+                "DateTime",
+                "Time",
+                "Domain",
+                "Email",
+                "IPAddress",
+                "MACAddress",
+                "Netmask",
+                "URL",
+                "Hexadecimal",
+                "HTML",
+                "UUID",
+            ]:
+                # This is a special type that should be referenced through ffTypes
+                type_str = f"ffTypes.{type_value}"
+            else:
+                # This is a built-in type name as string
+                type_str = type_value
+        else:
+            # This is a built-in type
+            type_str = type_value.__name__ if type_value else "None"
+
+        # For required parameters, just return the type
+        # For optional parameters, return type | None
+        return type_str if is_required else f"{type_str} | None = None"
+
+    def generate_typed_parameters_string(self, parsed_params):
+        """
+        Generates a string representing method parameters with type annotations.
+        Excludes 'id' parameter as it will be handled separately.
+        """
+        if not parsed_params:
+            return ""
+
+        required_params, optional_params = [], []
+        for name, details in parsed_params.items():
+            # Skip 'id' parameter as it will be handled separately
+            if name == "id":
+                continue
+
+            fixed_name = self.fix_name(name)
+            type_annotation = self.get_python_type_annotation(details, param_name=name)
+            # Check if parameter has a default value
+            if "= None" in type_annotation:
+                optional_params.append(f"{fixed_name}: {type_annotation}")
+            else:
+                required_params.append(f"{fixed_name}: {type_annotation}")
+
+        # Combine parameters with required ones first
+        return ", ".join(required_params + optional_params)
+
+    def extract_init_params_from_create_method(self, entity_name, entity_api_data):
+        """
+        Extract initialization parameters from the entity's create method.
+        Look for nested parameters under the entity's name.
+        """
+        methods_api_data = entity_api_data.get("methods", [])
+        create_method_data = None
+
+        # Find the create method data
+        if isinstance(methods_api_data, list):
+            for method_dict in methods_api_data:
+                if isinstance(method_dict, dict) and "create" in method_dict:
+                    create_method_data = method_dict["create"]
+                    break
+        elif isinstance(methods_api_data, dict) and "create" in methods_api_data:
+            create_method_data = methods_api_data["create"]
+
+        if not create_method_data:
+            logger.debug(f"No create method found for entity {entity_name}")
+            return ""
+
+        # Get parameters from create method
+        api_params_list = create_method_data.get(
+            "parameters", create_method_data.get("params", [])
+        )
+        if not isinstance(api_params_list, list):
+            logger.warning(
+                f"Parameters for create method in {entity_name} are not a list. Treating as empty."
+            )
+            return ""
+
+        # Parse all parameters
+        parsed_params = self.parse_api_parameters(api_params_list)
+
+        # Look for the entity parameter (singular form of entity_name if needed)
+        entity_param_name = entity_name
+        if entity_name.endswith("s") and entity_name[-2:] != "ss":
+            entity_param_name = entity_name[:-1]
+        # If we find the entity parameter and it has children, use those for init params
+        if entity_param_name in parsed_params and parsed_params[entity_param_name]["children"]:
+            entity_children = parsed_params[entity_param_name]["children"]
+
+            # Generate typed parameters for __init__ from the entity's children
+            required_params, optional_params = [], []
+            for name, details in entity_children.items():
+                fixed_name = self.fix_name(name)
+                type_annotation = self.get_python_type_annotation(details, param_name=name)
+
+                if "= None" in type_annotation:
+                    optional_params.append(f"{fixed_name}: {type_annotation}")
+                else:
+                    required_params.append(f"{fixed_name}: {type_annotation}")
+
+            # Format the parameters with proper indentation
+            param_lines = required_params + optional_params
+            return ",\n        ".join(param_lines)
+
+        return ""
+
+    def fill_method_template_custom(self, class_name, method_name_raw, method_api_data):
+        """Generate method code from template"""
+        logger.debug(f"Filling method template for {class_name}.{method_name_raw}")
+
+        template_str = self._load_template("method")
+        if not template_str:
+            return ""
+
+        method_name = self.fix_name(method_name_raw)
+
+        # Process API parameters
+        api_params_list = method_api_data.get("parameters", method_api_data.get("params", []))
+        if not isinstance(api_params_list, list):
+            logger.warning(
+                "Parameters for %s are not a list: %s. Treating as empty.",
+                method_name_raw,
+                api_params_list,
+            )
+            api_params_list = []
+
+        parsed_params = self.parse_api_parameters(api_params_list)
+
+        # Special handling for create method
+        self_param_inject = ""
+        entity_param_name = class_name.lower()
+
+        if method_name_raw == "create" and parsed_params.pop(entity_param_name, None):
+            logger.debug(
+                f"Found self-referential parameter '{entity_param_name}' in {class_name}.create"
+            )
+            self_param_inject = f'\n    params["{entity_param_name}"] = self'
+
+        typed_parameters_str = self.generate_typed_parameters_string(parsed_params)
+
+        # Process paths
+        paths_list = method_api_data.get("paths", [])
+        if not isinstance(paths_list, list):
+            logger.warning(
+                "Paths for %s are not a list: %s. Treating as empty.",
+                method_name_raw,
+                paths_list,
+            )
+            paths_list = []
+
+        compiled_paths_str = str(self.compile_paths(paths_list))
+
+        # Check if ID parameter is required
+        has_id_param = any(name == "id" for name, details in parsed_params.items())
+        id_snip = "\n    id = self.id  # set for params" if has_id_param else ""
+
+        # Apply template replacements
+        replacements = {
+            "method_name": method_name,
+            "typed_parameters": typed_parameters_str,
+            "path_list": compiled_paths_str,
+            "id_snip_if_needed": id_snip,
+            "self_param_inject": self_param_inject,
+        }
+
+        return self.template_manager.replace_placeholders(template_str, replacements)
+
+    def fill_entity_template_custom(self, entity_name, entity_api_data):
+        """Generate entity class code from template"""
+        logger.debug(f"Filling entity template for {entity_name}")
+
+        template_str = self._load_template("class")
+        if not template_str:
+            return ""
+
+        class_name = self.name_to_class(entity_name)
+
+        # Extract initialization parameters from create method
+        init_params = self.extract_init_params_from_create_method(entity_name, entity_api_data)
+
+        # Track renamed methods for patch_methods decorator
+        renamed_methods = {}
+        methods_api_data = entity_api_data.get("methods", [])
+        all_method_definitions = []
+
+        # Process methods based on data structure
+        all_method_definitions = self._process_methods(
+            methods_api_data, entity_name, class_name, renamed_methods
+        )
+
+        # Apply patch_methods decorator if there are any renamed methods
+        class_definition = f"class {class_name}({self.name_to_class(self.api_name)}):"
+        if renamed_methods:
+            class_definition = f"@patch_methods({renamed_methods})\n{class_definition}"
+
+        # Indent method definitions appropriately
+        methods_str = shift_text("\n".join(all_method_definitions), shift=1)
+
+        # Apply template replacements
+        replacements = {
+            "FeatureName": class_name,
+            "ProductName": self.name_to_class(self.api_name),
+            "init_params": init_params,
+            "class methods": methods_str,
+        }
+
+        template_str = self.template_manager.replace_placeholders(template_str, replacements)
+
+        # Replace class definition if we have renamed methods
+        if renamed_methods:
+            template_str = template_str.replace(
+                f"class {class_name}({self.name_to_class(self.api_name)}):", class_definition
+            )
+
+        return template_str
+
+    def _process_methods(self, methods_api_data, entity_name, class_name, renamed_methods):
+        """Process methods data and generate method definitions"""
+        all_method_definitions = []
+
+        # Handle both list and dict formats for methods
+        if isinstance(methods_api_data, list):
+            # List format: [{method_name: {method_data}}, {method_name2: {method_data2}}]
+            for method_dict in methods_api_data:
+                if isinstance(method_dict, dict):
+                    for raw_method_name, method_data in method_dict.items():
+                        # Save original name before fixing
+                        original_name = raw_method_name
+                        fixed_name = self.fix_name(raw_method_name)
+
+                        # If name was changed, record the mapping
+                        if original_name != fixed_name:
+                            renamed_methods[original_name] = fixed_name
+
+                        all_method_definitions.append(
+                            self.fill_method_template_custom(
+                                class_name, raw_method_name, method_data
+                            )
+                        )
+                else:
+                    # Handle the case where it's just a list of method names
+                    logger.warning(
+                        f"Method data for {method_dict} in {entity_name} is not a dictionary"
+                    )
+        elif isinstance(methods_api_data, dict):
+            # Dict format: {method_name: {method_data}, method_name2: {method_data2}}
+            for raw_method_name, method_data in methods_api_data.items():
+                # Save original name before fixing
+                original_name = raw_method_name
+                fixed_name = self.fix_name(raw_method_name)
+
+                # If name was changed, record the mapping
+                if original_name != fixed_name:
+                    renamed_methods[original_name] = fixed_name
+
+                all_method_definitions.append(
+                    self.fill_method_template_custom(class_name, raw_method_name, method_data)
+                )
+        else:
+            logger.warning(
+                "Methods data for %s is neither a list nor a dictionary: %s",
+                entity_name,
+                type(methods_api_data),
+            )
+
+        return all_method_definitions
+
+    def generate_ff_type_classes(self):
+        """Generate the content for the ffTypes class based on encountered types"""
+        if not self.ff_types:
+            return "pass  # No custom types needed"
+
+        template_f = Path("libs/templates/typed/ff_class.template")
+        if not template_f.exists():
+            logger.error(f"Unable to find ff_class template: {template_f.absolute()}")
+            return "pass  # Template not found"
+
+        with template_f.open("r") as f:
+            template_str = f.read()
+
+        class_definitions = []
+        for type_name, method_name in sorted(self.ff_types):
+            class_def = template_str.replace("~~ff_type~~", type_name)
+            class_def = class_def.replace("~~ff_method~~", method_name)
+            class_definitions.append(class_def)
+
+        return "\n    ".join(class_definitions)
+
+    def create_custom_lib_file(self):
+        """Create the custom library file for the API"""
+        logger.info(f"Creating custom library file for API: {self.api_name} v{self.api_version}")
+
+        # Generate entity templates
+        all_entity_templates = []
+        for entity_name, entity_api_data in self.api_dict.items():
+            if not isinstance(entity_api_data, dict):
+                logger.warning(f"Skipping entity {entity_name} as its data is not a dictionary.")
+                continue
+            all_entity_templates.append(
+                self.fill_entity_template_custom(entity_name, entity_api_data)
+            )
+
+        all_entity_templates_str = "\n\n".join(filter(None, all_entity_templates))
+
+        # Load main template
+        loaded_main_template = self._load_template("main")
+        if not loaded_main_template:
+            return
+
+        # Generate the ff_type_classes content
+        ff_type_classes = self.generate_ff_type_classes()
+
+        # Apply template replacements
+        replacements = {
+            "ProductName": self.name_to_class(self.api_name),
+            "feature classes": all_entity_templates_str,
+            "ff_type_classes": ff_type_classes,
+        }
+
+        loaded_main_template = self.template_manager.replace_placeholders(
+            loaded_main_template, replacements
+        )
+
+        # Save the generated file
+        save_file = Path(f"libs/generated/typed/{self.api_version}/{self.api_name}.py")
+        save_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write the file and format it
+        self._write_and_format_file(save_file, loaded_main_template)
+
+    def _write_and_format_file(self, file_path: Path, content: str):
+        """Write content to file and format with ruff"""
+        if file_path.exists():
+            logger.warning(f"Overwriting {file_path}")
+            file_path.unlink()
+
+        logger.info(f"Saving results to {file_path}")
+        file_path.write_text(content)
+
+        logger.info(f"running ruff on {file_path}")
+        try:
+            subprocess.run(["ruff", "format", str(file_path)], check=True)
+        except subprocess.CalledProcessError as e:
+            logger.warning(f"Ruff linting failed: {e}")
+
+
+@attr.s()
+class TypedMaker:
+    api_dict = attr.ib(repr=False)
+    api_name = attr.ib()
+    api_version = attr.ib()
+
+    def make(self):
+        """Make all the changes needed to create the typed library version"""
+        logger.info(
+            f"Starting typed library generation for API: {self.api_name} v{self.api_version}"
+        )
+        if not self.api_dict:
+            logger.error("API dictionary is empty. Cannot generate library.")
+            return
+
+        entity_maker = CustomEntityMaker(self.api_dict, self.api_name, self.api_version)
+        entity_maker.create_custom_lib_file()
+        logger.info(
+            f"Successfully generated typed library for API: {self.api_name} v{self.api_version}"
+        )

--- a/libs/templates/typed/class.template
+++ b/libs/templates/typed/class.template
@@ -1,0 +1,6 @@
+class ~~FeatureName~~(~~ProductName~~):
+    def __init__(self, ~~init_params~~):
+        params = {k: v for k, v in locals().items() if k not in ("self", "__class__") and v}
+        super().__init__(**params)
+
+~~class methods~~

--- a/libs/templates/typed/ff_class.template
+++ b/libs/templates/typed/ff_class.template
@@ -1,0 +1,2 @@
+class ~~ff_type~~:
+        ff_method = fauxfactory.~~ff_method~~

--- a/libs/templates/typed/main.template
+++ b/libs/templates/typed/main.template
@@ -1,0 +1,209 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "fauxfactory",
+#     "requests",
+# ]
+# ///
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import re
+import sys
+from typing import Literal
+
+import fauxfactory
+import requests
+
+
+SESSION_ENTITIES = set()
+CONN: APIConnection = None
+
+class APIConnection:
+    """Before interacting with the API, you must create an instance of this class."""
+    def __init__(self, **kwargs):
+        self.hostname = kwargs.pop("hostname", os.environ.get("TARGET_HOST"))
+        self.base_path = f"https://{self.hostname}"
+        auth = tuple((kwargs.pop("auth", os.environ.get("TARGET_AUTH"))).split(":"))
+        self.headers = {
+            "auth": auth,
+            "timeout": 120.0,
+            "verify": False,
+            "headers": {"content-type": "application/json"},
+        }
+        self.request_methods = {
+            "GET": requests.get,
+            "POST": requests.post,
+            "PUT": requests.put,
+            "DELETE": requests.delete,
+        }
+        global CONN
+        CONN = self
+
+
+class ffTypes:
+    ~~ff_type_classes~~
+
+
+def parse_annotations(annotations):
+    """Convert string type annotations to structured format with resolved types."""
+    result = {}
+    
+    for name, type_str in annotations.items():
+        required = "| None" not in type_str and "= None" not in type_str
+        
+        # Handle list[Entity.id] format
+        if match := re.search(r"list\[(\w+)\.(\w+)\]", type_str):
+            entity, attr = match.groups()
+            # Try to resolve entity class from any loaded module
+            entity_type = next((getattr(mod, entity) for mod_name, mod in sys.modules.items() 
+                              if hasattr(mod, entity)), entity)
+            result[name] = {"type": [{"type": entity_type, "attribute": attr}], "required": required}
+            continue
+            
+        # Handle Literal['val1', 'val2', ...] format
+        if match := re.search(r"Literal\[(.*?)\]", type_str):
+            result[name] = {"type": f"Literal[{match.group(1)}]", "required": required}
+            continue
+            
+        # Handle ffTypes.TypeName format
+        if match := re.search(r"ffTypes\.(\w+)", type_str):
+            result[name] = {"type": f"ffTypes.{match.group(1)}", "required": required}
+            continue
+            
+        # Handle standard Python types
+        base_type = type_str.split(" |")[0] if " | " in type_str else type_str
+        type_mapping = {"str": str, "int": int, "bool": bool, "list": list, "dict": dict}
+        
+        result[name] = {
+            "type": type_mapping.get(base_type, base_type),
+            "required": required
+        }
+    
+    return result
+
+
+def get_dependencies(annotations):
+    """Extract entity dependencies from parsed annotations."""
+    dependencies = []
+    
+    for name, info in annotations.items():
+        if isinstance(info["type"], list) and isinstance(info["type"][0], dict):
+            for item in info["type"]:
+                dependencies.append({
+                    "parameter": name,
+                    "entity_type": item["type"],
+                    "attribute": item["attribute"],
+                    "required": info["required"]
+                })
+    
+    return dependencies
+
+
+def patch_methods(renamed_methods):
+    """
+    Decorator to handle Python reserved keywords in method names.
+
+    example: @patch_methods({"global": "global_", "import": "import_"})
+    """
+
+    def decorator(cls):
+        # Store the renamed methods mapping as a class attribute
+        cls._renamed_methods = renamed_methods
+        if not hasattr(cls, "__getattr__"):
+            def __getattr__(self, name):
+                # Check if the name is in our renamed methods dictionary
+                if name in self.__class__._renamed_methods:
+                    # Get the actual method name
+                    renamed = self.__class__._renamed_methods[name]
+                    return getattr(self, renamed)
+                raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
+            cls.__getattr__ = __getattr__
+        return cls
+    return decorator
+
+
+class ~~ProductName~~:
+    def __init__(self, **kwargs):
+        self._add_attr(kwargs)
+
+    def _add_attr(self, attributes):
+        if isinstance(attributes, dict):
+            for key, value in attributes.items():
+                setattr(self, key, value)
+
+    def _format_payload(self, payload=None):
+        if isinstance(payload, dict):
+            payload = {
+                k: v._to_dict() if isinstance(v, ~~ProductName~~) else v
+                for k, v in payload.items()
+                if not k.startswith("_") and v is not None
+            }
+            try:
+                return json.dumps(payload)
+            except (TypeError, ValueError) as err:
+                raise Exception(
+                    f"Error! Unable to format payload {payload}. Reverting to original value."
+                ) from err
+        return payload
+
+    def _select_path(self, paths, params):
+        """Return the first matching (method, path) based on the params"""
+        if not isinstance(paths, list):
+            raise Exception(f"Expected paths to be list, got {paths}")
+        params = params if params else {}
+        for method, path in paths:
+            try:
+                path = path.format_map(params)
+                return method, path
+            except KeyError:
+                continue
+        return None, None
+
+    def _request(self, params):
+        if not isinstance(CONN, APIConnection):
+            raise Exception("APIConnection must be initialized before using Satellite classes.")
+        paths = params.pop("paths")
+        method, path = self._select_path(paths, params)
+        if not path:
+            raise Exception(f"No suitable paths found for {params}. Available: {paths.values()}")
+        path = CONN.base_path + path
+        payload = self._format_payload(params)
+        result = CONN.request_methods[method](url=path, data=payload, **CONN.headers)
+        if result.ok:
+            caller_inst = params.pop("self")
+            caller_inst._add_attr(result.json().get("result", result.json()))
+            if inspect.currentframe().f_back.f_code.co_name == "create":
+                SESSION_ENTITIES.add(caller_inst)
+        return result
+
+    def clean_session(self, max_attempts=5):
+        attempt = 1
+        while SESSION_ENTITIES and attempt <= max_attempts:
+            for entity in SESSION_ENTITIES[::-1]:
+                try:
+                    if entity.delete().ok:
+                        SESSION_ENTITIES.remove(entity)
+                except Exception as e:
+                    pass  # Ignore errors until we run out of attempts
+            attempt += 1
+        if SESSION_ENTITIES:
+            print(f"Some session entities could not be deleted: {SESSION_ENTITIES}")
+
+    def _to_dict(self):
+        """Return a JSON representation of the instance."""
+        return {
+            k: v._to_dict() if isinstance(v, ~~ProductName~~) else v
+            for k, v in self.__dict__.items()
+            if not k.startswith("_") and v
+        }
+
+
+~~feature classes~~
+
+MYCLASSES = {
+    name: obj for name, obj in inspect.getmembers(sys.modules[__name__])
+    if inspect.isclass(obj) and ~~ProductName~~ in obj.mro()
+}

--- a/libs/templates/typed/method.template
+++ b/libs/templates/typed/method.template
@@ -1,0 +1,5 @@
+def ~~method_name~~(self, ~~typed_parameters~~):
+    paths = ~~path_list~~~~id_snip_if_needed~~
+    params = {k: v for k, v in locals().items() if k[0] != "_" and v is not None}~~self_param_inject~~
+    return super()._request(params)
+

--- a/libs/templates/typed_advanced/class.template
+++ b/libs/templates/typed_advanced/class.template
@@ -1,0 +1,6 @@
+class ~~FeatureName~~(~~ProductName~~):
+    def __init__(self, ~~init_params~~):
+        params = {k: v for k, v in locals().items() if k not in ("self", "__class__") and v}
+        super().__init__(params=params)
+
+~~class methods~~

--- a/libs/templates/typed_advanced/ff_class.template
+++ b/libs/templates/typed_advanced/ff_class.template
@@ -1,0 +1,2 @@
+class ~~ff_type~~:
+        ff_method = fauxfactory.~~ff_method~~

--- a/libs/templates/typed_advanced/main.template
+++ b/libs/templates/typed_advanced/main.template
@@ -1,0 +1,237 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "fauxfactory",
+#     "requests",
+# ]
+# ///
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+from typing import types, Literal, get_args
+
+import fauxfactory
+import requests
+
+
+SESSION_ENTITIES = set()
+CONN: APIConnection = None
+
+class APIConnection:
+    """Before interacting with the API, you must create an instance of this class."""
+    def __init__(self, **kwargs):
+        self.hostname = kwargs.pop("hostname", os.environ.get("TARGET_HOST"))
+        self.base_path = f"https://{self.hostname}"
+        auth = tuple((kwargs.pop("auth", os.environ.get("TARGET_AUTH"))).split(":"))
+        self.headers = {
+            "auth": auth,
+            "timeout": 120.0,
+            "verify": False,
+            "headers": {"content-type": "application/json"},
+        }
+        self.request_methods = {
+            "GET": requests.get,
+            "POST": requests.post,
+            "PUT": requests.put,
+            "DELETE": requests.delete,
+        }
+        global CONN
+        CONN = self
+
+
+class ffTypes:
+    class Date:
+        ff_method = fauxfactory.gen_date
+
+    class Domain:
+        ff_method = fauxfactory.gen_domain
+
+    class IPAddress:
+        ff_method = fauxfactory.gen_ipaddr
+
+    class MACAddress:
+        ff_method = fauxfactory.gen_mac
+
+    class Time:
+        ff_method = fauxfactory.gen_time
+
+    class URL:
+        ff_method = fauxfactory.gen_url
+
+    class UUID:
+        ff_method = fauxfactory.gen_uuid
+
+
+def patch_methods(renamed_methods):
+    """
+    Decorator to handle Python reserved keywords in method names.
+
+    Args:
+        renamed_methods: Dictionary mapping reserved keywords to their renamed versions
+                        (e.g., {"global": "global_", "import": "import_"})
+
+    Returns:
+        A decorator that adds __getattr__ method to handle attribute lookup
+    """
+
+    def decorator(cls):
+        # Store the renamed methods mapping as a class attribute
+        cls._renamed_methods = renamed_methods
+
+        # Only create the __getattr__ method if it doesn't already exist
+        if not hasattr(cls, "__getattr__"):
+
+            def __getattr__(self, name):
+                # Check if the name is in our renamed methods dictionary
+                if name in self.__class__._renamed_methods:
+                    # Get the actual method name
+                    renamed = self.__class__._renamed_methods[name]
+                    # Return the renamed method
+                    return getattr(self, renamed)
+                # Let the standard attribute error be raised
+                raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
+
+            # Add the __getattr__ method to the class
+            cls.__getattr__ = __getattr__
+
+        return cls
+
+    return decorator
+
+
+class ~~ProductName~~:
+    def __init__(self, **kwargs):
+        if kwargs.pop("params", None):
+            caller_meth = inspect.currentframe()
+            self._fill_missing_parameters(caller_meth, self, params)
+        self._add_attr(kwargs)
+
+    def _add_attr(self, attributes):
+        if isinstance(attributes, dict):
+            for key, value in attributes.items():
+                setattr(self, key, value)
+
+    def _format_payload(self, payload=None):
+        if payload and not isinstance(payload, str):
+            try:
+                return json.dumps(payload)
+            except SyntaxError as err:
+                raise Exception(
+                    f"Error! Unable to format payload {payload}. Reverting to original value."
+                ) from err
+        return payload
+
+    def _create_dep(self, dep_type):
+        """Create a dependency based on the dependency type."""
+        # handle custom type annotations: MyClass["attr"]
+        if isinstance(dep_type, str):
+            parts = re.search(r"(\w+)\[['\"](\w+)['\"]\]", dep_type)
+            dep_type, attribute = MYCLASSES[parts.group(1)], parts.group(2)
+            d_inst = dep_type()
+            d_inst.create()
+            return getattr(d_inst, attribute, None)
+        # handle basic custom types: MyClass
+        if dep_type in MYCLASSES.values():
+            d_inst = dep_type()
+            d_inst.create()
+
+        # resolve simple types
+        if dep_type is bool:
+            return fauxfactory.gen_boolean()
+        if dep_type is int:
+            return fauxfactory.gen_number(min_value=1, max_value=10)
+        if dep_type is str:
+            return fauxfactory.gen_alpha()
+        if ff_func := getattr(fauxfactory, f"gen_{dep_type}", None):
+            return ff_func()
+        if dep_type == "date":
+            return fauxfactory.gen_date()
+
+        # handle Literal types
+        if hasattr(dep_type, "__origin__") and dep_type.__origin__ is Literal:
+            # Get the choices from the Literal type
+            choices = get_args(dep_type)
+            return fauxfactory.gen_choice(choices)
+
+        # We really should have returned by now
+        raise Exception(f"Do not know how to produce required parameter {dep_type}")
+
+    def _select_path(self, paths, params):
+        """Return the first matching (method, path) based on the params"""
+        if not isinstance(paths, list):
+            raise Exception(f"Expected paths to be list, got {paths}")
+        params = params if params else {}
+        for method, path in paths:
+            try:
+                path = path.format_map(params)
+                return method, path
+            except KeyError:
+                continue
+        return None, None
+
+    def _fill_missing_parameters(self, caller_method, caller_inst, params):
+        """Fill in missing parameters based on the caller's annotations."""
+        annotations = getattr(caller_method, "__annotations__", {})
+        caller_inst = caller_method.f_locals.get("self")
+        # iterate through the annotations and fill in missing required parameters
+        for name, spec in annotations.items():
+            if name in params or name == "self" or name == "return":
+                continue
+            if isinstance(spec, types.UnionType):
+                # There's a good chance it is a union with None, so we can skip it
+                if spec.__args__[-1] is None:
+                    continue
+                raise ValueError(f"Union type {spec} is not supported for {name}")
+            elif isinstance(spec, str) and spec.endswith("None"):  # Custom annotation
+                continue
+
+            # Skip adding the actual type objects to params
+            if spec is type or isinstance(spec, type):
+                continue
+
+            # If the type is a normal type or class
+            # get it from the caller's instance or create a new one
+            params[name] = getattr(caller_inst, name, self._create_dep(spec))
+
+    def _request(self, params):
+        if not isinstance(CONN, APIConnection):
+            raise Exception("APIConnection must be initialized before using ~~ProductName~~ classes.")
+        paths = params.pop("paths")
+        caller_inst = params.pop("self")
+        caller_meth = inspect.currentframe().f_back
+        self._fill_missing_parameters(caller_meth, caller_inst, params)
+        method, path = self._select_path(paths, params)
+        if not path:
+            raise Exception(f"No suitable paths found for {params}. Available: {paths.values()}")
+        path = CONN.base_path + path
+        payload = self._format_payload(params)
+        result = CONN.request_methods[method](url=path, data=payload, **CONN.headers)
+        if result.ok:
+            caller_inst._add_attr(result.json().get("result", result.json()))
+        if caller_meth.__name__ == "create":
+            SESSION_ENTITIES.add(caller_inst)
+        return result
+
+    def clean_session(self, max_attempts=5):
+        attempt = 1
+        while SESSION_ENTITIES and attempt <= max_attempts:
+            for entity in SESSION_ENTITIES:
+                try:
+                    if entity.delete().ok:
+                        SESSION_ENTITIES.remove(entity)
+                except Exception as e:
+                    pass  # Ignore errors until we run out of attempts
+            attempt += 1
+        if SESSION_ENTITIES:
+            print(f"Some session entities could not be deleted: {SESSION_ENTITIES}")
+
+
+~~feature classes~~
+
+MYCLASSES = {
+    name: obj for name, obj in inspect.getmembers(sys.modules[__name__])
+    if inspect.isclass(obj) and ~~ProductName~~ in obj.mro()
+}

--- a/libs/templates/typed_advanced/method.template
+++ b/libs/templates/typed_advanced/method.template
@@ -1,0 +1,5 @@
+def ~~method_name~~(self, ~~typed_parameters~~):
+    paths = ~~path_list~~~~id_snip_if_needed~~
+    params = {k: v for k, v in locals().items() if k[0] != "_" and v is not None}
+    return super()._request(params)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ description = "API Explorer: Discover, Track, Test."
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["apix", "api", "explorer", "discovery", "tracking", "testing"]
-authors = [
-    {name = "Jacob J Callahan", email = "jacob.callahan05@gmail.com"}
-]
+authors = [{ name = "Jacob J Callahan", email = "jacob.callahan05@gmail.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -38,12 +36,7 @@ dynamic = ["version"]
 Repository = "https://github.com/JacobCallahan/apix"
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit",
-    "pytest",
-    "pytest-randomly",
-    "ruff"
-]
+dev = ["pre-commit", "pytest", "pytest-randomly", "ruff"]
 
 [project.scripts]
 apix = "apix.commands:cli"
@@ -56,7 +49,7 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["apix"]
 
-[tool.setuptools_scm]  # same as use_scm_version=True in setup.py
+[tool.setuptools_scm] # same as use_scm_version=True in setup.py
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -69,39 +62,36 @@ target-version = "py311"
 [tool.ruff.lint]
 fixable = ["ALL"]
 select = [
-    "B",  # bugbear
-    "C90", # mccabe
-    "E",  # pycodestyle
-    "F",  # flake8
-    "G", # flake8-logging-format
-    "I", # isort
+    "B",    # bugbear
+    "C90",  # mccabe
+    "E",    # pycodestyle
+    "F",    # flake8
+    "G",    # flake8-logging-format
+    "I",    # isort
     "PERF", # Perflint rules
-    "PLC", # pylint
-    "PLE", # pylint
-    "PLR", # pylint
-    "PLW", # pylint
-    "PTH", # Use pathlib
-    "PT",  # flake8-pytest
+    "PLC",  # pylint
+    "PLE",  # pylint
+    "PLR",  # pylint
+    "PLW",  # pylint
+    "PTH",  # Use pathlib
+    "PT",   # flake8-pytest
     "RET",  # flake8-return
-    "RUF", # Ruff-specific rules
+    "RUF",  # Ruff-specific rules
     "SIM",  # flake8-simplify
-    "UP",  # pyupgrade
-    "W",  # pycodestyle
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
 ]
 ignore = [
-    "B019",  # lru_cache can lead to memory leaks - acceptable tradeoff
+    "B019",    # lru_cache can lead to memory leaks - acceptable tradeoff
     "PLR0911", # too many return statements - acceptable tradeoff
     "PLR0913", # too many arguments in function call - acceptable tradeoff
-    "PT004", # pytest underscrore prefix for non-return fixtures
-    "PT005", # pytest no underscrore prefix for return fixtures
-    "RET503", # missing explicit return
+    "RET503",  # missing explicit return
+    "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
 ]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
-known-first-party = [
-    "apix",
-]
+known-first-party = ["apix"]
 combine-as-imports = true
 
 [tool.ruff.lint.flake8-pytest-style]


### PR DESCRIPTION
This change largely centers around the addition of a new library generation that makes it easier to discover what parameters are available for each entity and their methods.

I also included a rough version of the "Advanced" form of the library, but that will need additional work to figure out exactly how best to auto-populate more complicated fields and prune unnecessary information from requests.

Here are some auto-generated snippets:
**__init__ parameters for classes that pass themselves during create**
Also note the use of custom fauxfactory types as well as literals to represent set options.
```python

class Operatingsystem(Satellite):
    def __init__(
        self,
        name: str,
        major: str,
        minor: str | None = None,
        description: ffTypes.IPAddress | None = None,
        family: str | None = None,
        release_name: str | None = None,
        os_parameters_attributes: list | None = None,
        password_hash: Literal["sha512", "sha256", "base64", "base64-windows", "md5"]
        | None = None,
        architecture_ids: list | None = None,
        provisioning_template_ids: list | None = None,
        medium_ids: list | None = None,
        ptable_ids: list | None = None,
    ):
        params = {k: v for k, v in locals().items() if k not in ("self", "__class__") and v}
        super().__init__(**params)
```

**Auto-inclusion of an instance's own instance for endpoints that need it**
This will be recursively converted into a dictionary in preparation for the json request.
```python
    def create(self, location_id: int | None = None, organization_id: int | None = None):
        paths = [("POST", "/api/operatingsystems")]
        params = {k: v for k, v in locals().items() if k[0] != "_" and v is not None}
        params["operatingsystem"] = self
        return super()._request(params)
```

**Auto-inclusion of an instance's id when needed**
```python
    def destroy(self, location_id: int | None = None, organization_id: int | None = None):
        paths = [("DELETE", "/api/operatingsystems/{id}")]
        id = self.id  # set for params
        params = {k: v for k, v in locals().items() if k[0] != "_" and v is not None}
        return super()._request(params)
```

Everything is auto-formatted with ruff post-generation to ensure it has a good, consistent style.