### PR TITLE
Refactor: Replace logzero with loguru for logging

### DIFF
--- a/apix/commands.py
+++ b/apix/commands.py
@@ -21,7 +21,7 @@ def _version():
     type=click.Choice(["debug", "info", "warning", "error", "critical"]),
     default="info",
     help="The log level to use.",
-    callback=lambda ctx, param, value: logger.setup_logzero(value),
+    callback=lambda ctx, param, value: logger.setup_loguru(value),
     is_eager=True,
     expose_value=False,
 )

--- a/apix/diff.py
+++ b/apix/diff.py
@@ -1,7 +1,7 @@
 """Determine the changes between two API versions."""
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 import yaml
 
 from apix.helpers import get_latest, get_previous, load_api

--- a/apix/explore.py
+++ b/apix/explore.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import time
 
 import aiohttp
-from logzero import logger
+from loguru import logger
 import requests
 import yaml
 

--- a/apix/helpers.py
+++ b/apix/helpers.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import html
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 import yaml
 
 

--- a/apix/libtools/advanced.py
+++ b/apix/libtools/advanced.py
@@ -2,7 +2,7 @@
 import builtins
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 
 from apix.helpers import merge_dicts, shift_text
 

--- a/apix/libtools/basic.py
+++ b/apix/libtools/basic.py
@@ -2,7 +2,7 @@
 import builtins
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 
 from apix.helpers import shift_text
 

--- a/apix/libtools/intermediate.py
+++ b/apix/libtools/intermediate.py
@@ -2,7 +2,7 @@
 import builtins
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 
 from apix.helpers import shift_text
 

--- a/apix/libtools/libmaker.py
+++ b/apix/libtools/libmaker.py
@@ -1,6 +1,6 @@
 """This module provides the capability to create a new nailgun version."""
 
-from logzero import logger
+from loguru import logger
 
 from apix import helpers
 from apix.libtools import advanced, basic, intermediate, nailgun, typed

--- a/apix/libtools/nailgun.py
+++ b/apix/libtools/nailgun.py
@@ -1,7 +1,7 @@
 """This module provides the capability to create a new nailgun version."""
 from pathlib import Path
 
-from logzero import logger
+from loguru import logger
 
 
 class EntityMaker:

--- a/apix/libtools/typed.py
+++ b/apix/libtools/typed.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import re
 import subprocess
 
-from logzero import logger
+from loguru import logger
 import yaml
 
 from apix.helpers import shift_text

--- a/apix/logger.py
+++ b/apix/logger.py
@@ -1,32 +1,34 @@
 """Module handling internal and dependency logging."""
-import logging
+import sys
 
-import logzero
+from loguru import logger
 import urllib3
 
 
-def setup_logzero(level="info", path="logs/apix.log"):
-    log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
-    if level == "debug":
-        level = logging.DEBUG
-        log_fmt = (
-            "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"
-            "%(end_color)s %(message)s"
-        )
-    elif level == "info":
-        level = logging.INFO
-    elif level == "warning":
-        level = logging.WARNING
-    elif level == "error":
-        level = logging.ERROR
-    elif level == "critical":
-        level = logging.CRITICAL
-
-    formatter = logzero.LogFormatter(fmt=log_fmt)
-    logzero.setup_default_logger(formatter=formatter)
-    logzero.loglevel(level)
-    logzero.logfile(path, loglevel=level, maxBytes=1e9, backupCount=3, formatter=formatter)
+def setup_loguru(level="info", path="logs/apix.log"):
+    logger.remove()
+    console_format = (
+        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+        "<level>{level: <8}</level> | "
+        "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
+        "<level>{message}</level>"
+    )
+    file_format = (
+        "{time:YYYY-MM-DD HH:mm:ss.SSS} | " "{level: <8} | " "{name}:{function}:{line} - {message}"
+    )
+    logger.add(
+        sys.stderr,
+        level=level.upper(),
+        format=console_format,
+    )
+    logger.add(
+        path,
+        level=level.upper(),
+        rotation="10 MB",
+        retention="3 days",
+        format=file_format,
+    )
 
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-setup_logzero()
+setup_loguru()

--- a/apix/parsers/apipie.py
+++ b/apix/parsers/apipie.py
@@ -6,7 +6,7 @@ Parser classes must currently implement the following methods:
     yaml_format - Returns yaml-friendly dict of the compiled data.
     scrape_content - Returns a dict of params and paths from a single page.
 """
-from logzero import logger
+from loguru import logger
 
 from apix.helpers import clean_string
 

--- a/apix/parsers/apipie_old.py
+++ b/apix/parsers/apipie_old.py
@@ -6,7 +6,7 @@ Parser classes must currently implement the following methods:
     yaml_format - Returns yaml-friendly dict of the compiled data.
     scrape_content - Returns a dict of params and paths from a single page.
 """
-from logzero import logger
+from loguru import logger
 from lxml import html
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # "cchardet",
     "click",
     "rich-click",
-    "loguru~=0.7.2",
+    "loguru",
     "lxml",
     "setuptools",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # "cchardet",
     "click",
     "rich-click",
-    "logzero",
+    "loguru~=0.7.2",
     "lxml",
     "setuptools",
     "pyyaml",


### PR DESCRIPTION
This commit replaces the `logzero` logging library with `loguru`.

The `apix/logger.py` module has been updated to use `loguru`'s API for logger configuration, including setting log formats, levels, and file rotation.

All instances of `logzero.logger` throughout the codebase have been replaced with `from loguru import logger` and the corresponding `logger` methods.

The `pyproject.toml` file has been updated to remove `logzero` and add `loguru` as a project dependency.

Verification steps performed:
- `pre-commit run --all-files` passed.
- `pip install .` completed successfully.
- `apix --help` executed without errors.